### PR TITLE
fix: allow column names to start with number [DB-22576, DB-22529]

### DIFF
--- a/src/metabase/driver/ocient.clj
+++ b/src/metabase/driver/ocient.clj
@@ -294,3 +294,11 @@
 (defmethod sql.qp/unix-timestamp->honeysql [:ocient :microseconds]
   [driver _ field-or-value]
   (sql.qp/unix-timestamp->honeysql driver :seconds (hx// field-or-value (hsql/raw 1000000))))
+
+;; Remove backslash when column name starts with a number
+(defmethod driver/describe-table :ocient
+  [driver database table]
+  (let [table-description (sql-jdbc.sync/describe-table driver database table)]
+            (assoc table-description :fields
+              (set (mapv #(update % :name (fn [name] (clojure.string/replace-first name #"^\\" "")))
+                         (get table-description :fields))))))


### PR DESCRIPTION
<!-- Please summarize the change(s) here and mention any related Jira ticket(s) (e.g. DB-1) in the title. -->
# Overview
Column names that start with a number are stored as `'lsr_5g_base.\5g_nr_rsrp'` instead of `'lsr_5g_base.5g_nr_rsrp'`. When Metabase reads the columns, the name is stored with the `\`. This code strips the `\` so that the fingerprint can run successfully.

Also tested with a custom table
> CREATE TABLE "public"."test_w_quotes_escaped"(
>    "\1id" INT NOT NULL,
>    CLUSTERING INDEX idx01 ("\1id")
> ) AS SELECT 7;

to make sure that literal `\` in the column name still fingerprint properly.

# Tasks
<!-- Check the boxes that apply by changing "[ ]" to "[x]". -->
- [ ] Version in `./project.clj` has been updated
- [ ] Version in `./resources/metabase-plugin.yaml` has been updated