### PR TITLE
Fix make test-tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ build:
 	clojure -X:build :project-dir "\"$(shell pwd)\""
 
 # Run Metabase
-run: build
-	clojure -X:run :project-dir "\"$(shell pwd)\""
+run:
+	clojure -M:run > $(shell pwd)/metabase.log 2>&1 &
 
 # Run Ocient unit tests
 run-unit-test:

--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.ocient/ocient-jdbc4$jar-with-dependencies {:mvn/version "2.93"}}
+ {com.ocient/ocient-jdbc4$jar-with-dependencies {:mvn/version "2.94"}}
 
  :mvn/repos
  {"sonatype" {:url "https://oss.sonatype.org/content/groups/staging/"}}

--- a/deps.edn
+++ b/deps.edn
@@ -60,6 +60,15 @@
                  ;; prevent Java icon from randomly popping up in macOS dock
                  "-Djava.awt.headless=true"]}
 
+  ;; run the dev server with
+  ;; clojure -M:run
+  :run
+  {:extra-deps {metabase/metabase-core {:local/root "metabase"}}
+   :main-opts ["-m" "metabase.core"]
+   :jvm-opts  ["-Dmb.run.mode=dev"
+               "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
+               "-Dmb.jetty.port=3000"]}
+
   ;; includes unit test code as source paths. Run unit tests with clojure -X:dev:unit-test
   :unit-test
   {:extra-paths ["test" "metabase/test"]


### PR DESCRIPTION
<!-- Please summarize the change(s) here and mention any related Jira ticket(s) (e.g. DB-1) in the title. -->
# Overview
This work is not complete. I am just posting my progress to hand off. Rather than branch directly off of [user/jwilliams/make-run](https://github.com/Xeograph/metabase-ocient-driver/tree/user/jwilliams/make-run). I copied the change into this branch so we avoid nested branches. Fixing this work is necessary for finishing [DB-22298](https://github.com/Xeograph/metabase-ocient-driver/tree/user/bschwartz/DB-22298).

I wanted to make sure that test-tarball not only ran correctly, but that the test uberjar performed correctly afterwards. For getting test-tarball to generate an artifact successfully, all I had to do was change the file copy from
`COPY test/metabase/test/data/* ./test/metabase/test/data/`
`COPY test/metabase/driver/* ./test/metabase/driver/`
to 
`COPY test/ /build/metabase/modules/drivers/ocient/`


Getting the tarball to run correctly is still in progress. In my testing, it looks like we switched to a different version of Metabase (v0.44.4) to build the tarball off of. So some modifications were made in the patch. I did not have time to test if all of them were necessary. For some of the tests in this version of metabase, we need to run `yarn build-static-viz` [(source)](https://github.com/metabase/metabase/blob/master/test/metabase/pulse/render/body_test.clj#L13) in order to run some of the tests. The command needs to run before building the uberjar, but I had not set up the Dockerfile to use `yarn`.

After yarn is set up, I believe it should run correctly.

# Tasks
<!-- Check the boxes that apply by changing "[ ]" to "[x]". -->
- [ ] Set up the Dockerfile to use yarn
- [ ] Version in `./project.clj` has been updated
- [ ] Version in `./resources/metabase-plugin.yaml` has been updated