### PR TITLE
fix: disable 'sso' authentication-method which needs a bit of work before primetime [DB-23044]

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -66,6 +66,8 @@
   {:extra-deps {metabase/metabase-core {:local/root "metabase"}}
    :main-opts ["-m" "metabase.core"]
    :jvm-opts  ["-Dmb.run.mode=dev"
+               "-Dmb.jetty.async.response.timeout=86400000" ; increase query timeout (Web UI => MB)
+               "-Dmb.db.connection.timeout.ms=300000"       ; increase connection timeout to 5 minutes
                "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
                "-Dmb.jetty.port=3000"]}
 

--- a/test/metabase/driver/ocient_unit_test.clj
+++ b/test/metabase/driver/ocient_unit_test.clj
@@ -18,7 +18,7 @@
                                                                             :port               4050
                                                                             :db                 "metabase"
                                                                             :additional-options "loglevel=DEBUG;logfile=jdbc_trace.out"}))))
-                  (testing " marshal Single Sign-On tokens (toggle)"
+                  (testing " for Single Sign-On tokens (toggle)"
                     (is (= {:classname   "com.ocient.jdbc.JDBCDriver"
                             :subprotocol "ocient"
                             :statementPooling     "OFF"
@@ -32,7 +32,7 @@
                                                                             :sso                true
                                                                             :token-type         "access_token"
                                                                             :token              "********"}))))
-                  (testing " marshal Single Sign-On tokens (drop-down)"
+                  (testing " for Single Sign-On tokens (drop-down)"
                     (is (= {:classname   "com.ocient.jdbc.JDBCDriver"
                             :subprotocol "ocient"
                             :statementPooling     "OFF"
@@ -43,7 +43,7 @@
                            (sql-jdbc.conn/connection-details->spec :ocient {:host               "sales-sql0"
                                                                             :port               4050
                                                                             :db                 "metabase"
-                                                                            :authentication-method                "sso"
+                                                                            :authentication-method                "sso_token"
                                                                             :token-type         "access_token"
                                                                             :token              "********"}))))
                   (testing " strip trailing semicolon in additional options"


### PR DESCRIPTION
<!-- Please summarize the change(s) here and mention any related Jira ticket(s) (e.g. DB-1) in the title. -->
# Overview
Access Token support is still maintained.

# Tasks
<!-- Check the boxes that apply by changing "[ ]" to "[x]". -->
- [ ] Version in `./project.clj` has been updated
- [ ] Version in `./resources/metabase-plugin.yaml` has been updated