### PR TITLE
[DB-31546] Don't get system tables when getting views

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metabase/ocient-driver "v1.2.1"
+(defproject metabase/ocient-driver "v1.2.2"
   :min-lein-version "2.5.0"
 
   :repositories {"project" "file:repo"}

--- a/resources/metabase-plugin.yaml
+++ b/resources/metabase-plugin.yaml
@@ -1,7 +1,7 @@
 # Complete list of options here: https://github.com/metabase/metabase/wiki/Metabase-Plugin-Manifest-Reference
 info:
   name: Metabase Ocient Driver
-  version: v1.2.1
+  version: v1.2.2
   description: Allows Metabase to connect to Ocient databases.
 
 driver:

--- a/src/metabase/driver/ocient.clj
+++ b/src/metabase/driver/ocient.clj
@@ -437,7 +437,7 @@
    These are returned as a set of maps, the same format as `:tables` returned by `describe-database`."
   [database]
   (try (set (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                        ["LIST VIEWS;"]))
+                        ["SELECT schema AS \"schema\", name AS \"name\" FROM sys.views WHERE schema NOT IN ('sys', 'information_schema', 'syslookup', 'sysgdc');"]))
        (catch Throwable e
          (log/error e "Failed to fetch views for this database"))))
 


### PR DESCRIPTION
DB-31546 
# Overview
Fixes issue where we were getting system tables when getting views. Also fixes issue where we weren't seeing any views on some systems.

# Tasks
<!-- Check the boxes that apply by changing "[ ]" to "[x]". -->
- [x] Version in `./project.clj` has been updated
- [x] Version in `./resources/metabase-plugin.yaml` has been updated